### PR TITLE
fix: adjust clean up

### DIFF
--- a/nimv.bat
+++ b/nimv.bat
@@ -396,7 +396,9 @@ if exist "%NIM_BIN_PATH%\nim.exe" (
 
     echo Cleaning up installation directory...
     cd /d "%NIM_DIR%"
-    for /d %%i in (*) do if not "%%i"=="bin" rd /s /q "%%i"
+    set "exclude=|bin|lib|dist|config|compiler|"
+    for /d %%i in (*) do if "!exclude:|%%~i|=!" equ "%exclude%" rd /s /q "%%~i"
+    for /d %%i in (dist\*) do if not "%%i"=="dist\checksums" rd /s /q "%%i"
     for %%i in (*) do del /q "%%i"
 
     :: Remove nim_csources binary from bin

--- a/nimv.sh
+++ b/nimv.sh
@@ -384,7 +384,8 @@ if [ -d "$NIM_BIN_PATH" ]; then
 
     echo "Cleaning up installation directory..."
     cd "$NIM_DIR" || exit 1
-    find . -mindepth 1 -maxdepth 1 ! -name 'bin' -exec rm -rf {} +
+    find . -mindepth 1 -maxdepth 1 ! -name 'bin' ! -name 'lib' ! -name 'dist' ! -name 'config' ! -name 'compiler' -exec rm -rf {} +
+    find dist -mindepth 1 -maxdepth 1 ! -name 'checksums' -exec rm -rf {} +
     rm -f "$NIM_BIN_PATH"/nim_csources*
 
     echo "Done."


### PR DESCRIPTION
PR intended to fix Nim installation issue, we have in the [codex-storage/nim-lang-docker](https://github.com/codex-storage/nim-lang-docker).

During https://github.com/codex-storage/codex-network-crawler/pull/6 implementation, it was observed that `nimv` do a very strong clean up and some stuff like `nimble update nimble` is not working on a clean Ubuntu 24.04 VM.

The proposal lis to leave some additional/required folders
```shell
# du -hs .nimv/2.0.14/Nim
71M    .nimv/2.0.14/Nim

# du -hs .nimv/2.0.14/Nim/*
35M    .nimv/2.0.14/Nim/bin
31M    .nimv/2.0.14/Nim/compiler
48K    .nimv/2.0.14/Nim/config
544K   .nimv/2.0.14/Nim/dist
5.4M   .nimv/2.0.14/Nim/lib
```
*compiler* folder was required to build a new `nimble` package and probably we can delete `nim1` and `nim2` binaries from it, but let's consider/address that later.

Updated shell was fully checked on Ubuntu and works as expected, while batch was checked manually just for folders clean up, but changes are very straight-forward.